### PR TITLE
config updates, xbrowsering final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,6 @@
 			<version>1.7.21</version>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
-		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
 			<version>20190722</version>


### PR DESCRIPTION
CVE-2019-17571
moderate severity
Vulnerable versions: >= 1.2, <= 1.2.27
Patched version: No fix
Included in Log4j 1.2 is a SocketServer class that is vulnerable to deserialization of untrusted data which can be exploited to remotely execute arbitrary code when combined with a deserialization gadget when listening to untrusted network traffic for log data. This affects Log4j versions up to 1.2 up to 1.2.17.